### PR TITLE
fix exception caused by url_options.protocol having :// in it

### DIFF
--- a/lib/actionmailer_with_request.rb
+++ b/lib/actionmailer_with_request.rb
@@ -26,7 +26,7 @@ module ActionMailerWithRequest
           if request
             host     = request.host
             port     = request.port
-            protocol = request.protocol
+            protocol = request.protocol.gsub(%r{://}, '')
             standard_port = request.standard_port
 
             defaults[:protocol] = protocol


### PR DESCRIPTION
see https://github.com/Mange/roadie/issues/52

request.protocol returns http://, at least in newer Rails versions.
Remove the :// if it exists.
