### PR TITLE
Add license to gemspec

### DIFF
--- a/actionmailer-with-request.gemspec
+++ b/actionmailer-with-request.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  s.license       = 'MIT'
 
   s.add_dependency "rails", ">= 3"
 end


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.